### PR TITLE
Dojo_task5　APIで自社の最新情報を取得し画面表示する

### DIFF
--- a/task5.css
+++ b/task5.css
@@ -1,0 +1,36 @@
+html,
+body {
+  height: 100%;
+  margin: 0;
+	padding: 5%;
+}
+
+main{
+	height: 100%;
+}
+
+table {
+	height: 30%;
+	margin:auto;
+	text-align: center;
+}
+
+td {
+  border: 1px solid;
+	vertical-align: middle; 
+	padding: 5px;
+}
+
+
+.ir{
+	background-color: antiquewhite;
+}
+
+.company{
+	background-color: rgb(199, 199, 230);
+}
+
+.product{
+	background-color: rgb(196, 228, 208);
+}
+

--- a/task5.html
+++ b/task5.html
@@ -39,19 +39,19 @@
 				for (let i = 0; i < tdElements.length; i++) { 
 					
 					if (tdElements[i]  === cellElemForDay) {
-						tdElements[i].appendChild(document.createTextNode(`${eachdata.day.value}`));
+						tdElements[i].appendChild(document.createTextNode(`${eachData.day.value}`));
 					}
 					
 					if (tdElements[i] === cellElemForCategory) {
-						tdElements[i].appendChild(document.createTextNode(`${eachdata.category.value}`));
-						tdElements[i].setAttribute('class',`${eachdata.label.value}`)
+						tdElements[i].appendChild(document.createTextNode(`${eachData.category.value}`));
+						tdElements[i].setAttribute('class',`${eachData.label.value}`)
 					}
 					
 					if (tdElements[i] === cellElemForNews) {
 						const newsLink = document.createElement('a');
-						newsLink.textContent = eachdata.content.value;
-						newsLink.href = eachdata.url.value;		
-						newsLink.target = eachdata.target.value; 		
+						newsLink.textContent = eachData.content.value;
+						newsLink.href = eachData.url.value;		
+						newsLink.target = eachData.target.value; 		
 						tdElements[i].appendChild(newsLink);
 					}
 				}

--- a/task5.html
+++ b/task5.html
@@ -13,51 +13,6 @@
   <table id="cybozuNewsTable"></table>
 </main>
 </body>
-<script>
- 'use strict';
-	const getDojoData = async () => {
-		const query = 'limit 10';
-		await axios.get('https://54o76ppvn8.execute-api.ap-northeast-1.amazonaws.com/prod/bb-dojo',
-		{params: {
-			id: 'dojo',
-			query: query,
-		}}).then((value) =>{
-			const keys = Object.keys(value.data); 
-			keys.forEach((key)=>{ 
-				const eachData = value.data[key]
-
-				const table = document.getElementById('cybozuNewsTable') 
-				const trElem = table.insertRow(-1);
-
-				const cellElemForDay = trElem.insertCell(0);
-				const cellElemForCategory = trElem.insertCell(1);
-				const cellElemForNews = trElem.insertCell(2);
-				const tdElements = [cellElemForDay,cellElemForCategory,cellElemForNews]
-
-				tdElements.forEach((tdElement)=>{
-					if (tdElements === cellElemForDay) {
-						tdElement.appendChild(document.createTextNode(`${eachData.day.value}`));
-					}
-					
-					if (tdElement === cellElemForCategory) {
-						tdElement.appendChild(document.createTextNode(`${eachData.category.value}`));
-						tdElement.setAttribute('class',`${eachData.label.value}`)
-					}
-					
-					if (tdElement === cellElemForNews) {
-						const newsLink = document.createElement('a');
-						newsLink.textContent = eachData.content.value;
-						newsLink.href = eachData.url.value;		
-						newsLink.target = eachData.target.value; 		
-						tdElement.appendChild(newsLink);
-					}
-				})
-				
-			})
-		 }).catch( (error) =>{ 
-			console.log(error)
-		 });
-	}
-	getDojoData();
+<script src="./task5.js">
 </script>
 </html>

--- a/task5.html
+++ b/task5.html
@@ -45,7 +45,7 @@
 				newsLink.target = val.data[key].target.value; 		
 				cellElem[2].appendChild(newsLink);
 			})
-		 }).catch( (err) =>{ 
+		 }).catch((err) =>{ 
 			console.log(err)
 		 });
 	}

--- a/task5.html
+++ b/task5.html
@@ -46,7 +46,7 @@
 				cellElem[2].appendChild(newsLink);
 			})
 		 }).catch((err) =>{ 
-			console.log(err)
+			console.error(error)
 		 });
 	}
 	getDojoData();

--- a/task5.html
+++ b/task5.html
@@ -16,45 +16,42 @@
 <script>
  'use strict';
 	const getDojoData = async () => {
-		let query = 'limit 10';
+		const query = 'limit 10';
 		await axios.get('https://54o76ppvn8.execute-api.ap-northeast-1.amazonaws.com/prod/bb-dojo',
 		{params: {
 			id: 'dojo',
 			query: query,
-		 }})
-		 .then((val) =>{
-			console.log(val)
-			const keys = Object.keys(val.data); 
+		}}).then((value) =>{
+			const keys = Object.keys(value.data); 
 			keys.forEach((key)=>{ 
-				const eachData = val.data[key]
+				const eachData = value.data[key]
 
-				const tbl = document.getElementById('cybozuNewsTable') 
-				const trElem = tbl.insertRow(-1);
+				const table = document.getElementById('cybozuNewsTable') 
+				const trElem = table.insertRow(-1);
 
 				const cellElemForDay = trElem.insertCell(0);
 				const cellElemForCategory = trElem.insertCell(1);
 				const cellElemForNews = trElem.insertCell(2);
 				const tdElements = [cellElemForDay,cellElemForCategory,cellElemForNews]
 
-				for (let i = 0; i < tdElements.length; i++) { 
-					
-					if (tdElements[i]  === cellElemForDay) {
-						tdElements[i].appendChild(document.createTextNode(`${eachData.day.value}`));
+				tdElements.forEach((tdElement)=>{
+					if (tdElements === cellElemForDay) {
+						tdElement.appendChild(document.createTextNode(`${eachData.day.value}`));
 					}
 					
-					if (tdElements[i] === cellElemForCategory) {
-						tdElements[i].appendChild(document.createTextNode(`${eachData.category.value}`));
-						tdElements[i].setAttribute('class',`${eachData.label.value}`)
+					if (tdElement === cellElemForCategory) {
+						tdElement.appendChild(document.createTextNode(`${eachData.category.value}`));
+						tdElement.setAttribute('class',`${eachData.label.value}`)
 					}
 					
-					if (tdElements[i] === cellElemForNews) {
+					if (tdElement === cellElemForNews) {
 						const newsLink = document.createElement('a');
 						newsLink.textContent = eachData.content.value;
 						newsLink.href = eachData.url.value;		
 						newsLink.target = eachData.target.value; 		
-						tdElements[i].appendChild(newsLink);
+						tdElement.appendChild(newsLink);
 					}
-				}
+				})
 				
 			})
 		 }).catch( (error) =>{ 

--- a/task5.html
+++ b/task5.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Document</title>
+		<link rel="stylesheet" type="text/css" href="./task5.css">
+		<script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
+</head>
+<body>
+<main>
+  <table id="cybozuNewsTable"></table>
+</main>
+</body>
+<script>
+ 'use strict';
+	const getDojoData = async () => {
+		let query = 'limit 10';
+		await axios.get('https://54o76ppvn8.execute-api.ap-northeast-1.amazonaws.com/prod/bb-dojo',
+		{params: {
+			id: 'dojo',
+			query: query,
+		 }})
+		 .then((val) =>{
+			console.log(val)
+			const keys = Object.keys(val.data); 
+			keys.forEach((key)=>{ 
+				
+				const tbl = document.getElementById('cybozuNewsTable') 
+				const trElem = tbl.insertRow(-1);
+
+				const cellElem = {};
+				for (let i = 0; i <= 2; i++) { //１つのtrの中で表示するテーブルデータの数(日時、カテゴリ、内容の合計3つ)
+					cellElem[i] = trElem.insertCell(i);
+				}
+				
+				cellElem[0].appendChild(document.createTextNode(`${val.data[key].day.value}`));
+				cellElem[1].appendChild(document.createTextNode(`${val.data[key].category.value}`));
+				cellElem[1].setAttribute('class',`${val.data[key].label.value}`)
+				
+				const newsLink = document.createElement('a');
+				newsLink.textContent = val.data[key].content.value;
+				newsLink.href = val.data[key].url.value;		
+				newsLink.target = val.data[key].target.value; 		
+				cellElem[2].appendChild(newsLink);
+			})
+		 }).catch( (err) =>{ 
+			console.log(err)
+		 });
+	}
+	getDojoData();
+</script>
+</html>

--- a/task5.html
+++ b/task5.html
@@ -26,27 +26,40 @@
 			console.log(val)
 			const keys = Object.keys(val.data); 
 			keys.forEach((key)=>{ 
-				
+				const eachdata = val.data[key]
+
 				const tbl = document.getElementById('cybozuNewsTable') 
 				const trElem = tbl.insertRow(-1);
 
-				const cellElem = {};
-				for (let i = 0; i <= 2; i++) { //１つのtrの中で表示するテーブルデータの数(日時、カテゴリ、内容の合計3つ)
-					cellElem[i] = trElem.insertCell(i);
+				const cellElemForDay = trElem.insertCell(0);
+				const cellElemForCategory = trElem.insertCell(1);
+				const cellElemForNews = trElem.insertCell(2);
+				
+				const tdElements = [cellElemForDay,cellElemForCategory,cellElemForNews]
+
+				for (let i = 0; i < tdElements.length; i++) { 
+					
+					if (tdElements[i]  === cellElemForDay) {
+						tdElements[i].appendChild(document.createTextNode(`${eachdata.day.value}`));
+					}
+					
+					if (tdElements[i] === cellElemForCategory) {
+						tdElements[i].appendChild(document.createTextNode(`${eachdata.category.value}`));
+						tdElements[i].setAttribute('class',`${eachdata.label.value}`)
+					}
+					
+					if (tdElements[i] === cellElemForNews) {
+						const newsLink = document.createElement('a');
+						newsLink.textContent = eachdata.content.value;
+						newsLink.href = eachdata.url.value;		
+						newsLink.target = eachdata.target.value; 		
+						tdElements[i].appendChild(newsLink);
+					}
 				}
 				
-				cellElem[0].appendChild(document.createTextNode(`${val.data[key].day.value}`));
-				cellElem[1].appendChild(document.createTextNode(`${val.data[key].category.value}`));
-				cellElem[1].setAttribute('class',`${val.data[key].label.value}`)
-				
-				const newsLink = document.createElement('a');
-				newsLink.textContent = val.data[key].content.value;
-				newsLink.href = val.data[key].url.value;		
-				newsLink.target = val.data[key].target.value; 		
-				cellElem[2].appendChild(newsLink);
 			})
-		 }).catch((err) =>{ 
-			console.error(error)
+		 }).catch( (err) =>{ 
+			console.log(err)
 		 });
 	}
 	getDojoData();

--- a/task5.html
+++ b/task5.html
@@ -26,7 +26,7 @@
 			console.log(val)
 			const keys = Object.keys(val.data); 
 			keys.forEach((key)=>{ 
-				const eachdata = val.data[key]
+				const eachData = val.data[key]
 
 				const tbl = document.getElementById('cybozuNewsTable') 
 				const trElem = tbl.insertRow(-1);
@@ -34,7 +34,6 @@
 				const cellElemForDay = trElem.insertCell(0);
 				const cellElemForCategory = trElem.insertCell(1);
 				const cellElemForNews = trElem.insertCell(2);
-				
 				const tdElements = [cellElemForDay,cellElemForCategory,cellElemForNews]
 
 				for (let i = 0; i < tdElements.length; i++) { 
@@ -58,8 +57,8 @@
 				}
 				
 			})
-		 }).catch( (err) =>{ 
-			console.log(err)
+		 }).catch( (error) =>{ 
+			console.log(error)
 		 });
 	}
 	getDojoData();

--- a/task5.js
+++ b/task5.js
@@ -1,0 +1,37 @@
+(() => {
+	'use strict';
+	const getDojoData = async () => {
+		const query = 'limit 4';
+		await axios.get('https://54o76ppvn8.execute-api.ap-northeast-1.amazonaws.com/prod/bb-dojo',
+		{params: {
+			id: 'dojo',
+			query: query,
+		}}).then((value) =>{
+			const eachNewskeys = Object.keys(value.data); 
+			eachNewskeys.forEach((key)=>{ 
+				const eachData = value.data[key]
+
+				const table = document.getElementById('cybozuNewsTable')
+				const tableRow = document.createElement('tr');
+				
+				const  rowForDay = document.createElement('td');
+				rowForDay.innerHTML = eachData.day.value;
+				tableRow.appendChild(rowForDay);
+
+				const rowForCategory = document.createElement('td');
+				rowForCategory.innerHTML = eachData.category.value;
+				rowForCategory.setAttribute('class',`${eachData.label.value}`)
+				tableRow.appendChild(rowForCategory);
+
+				const  rowForContent = document.createElement('td');
+				rowForContent.innerHTML = `<a href="${eachData.url.value}" target="${eachData.target.value}">${eachData.content.value}</a>`;			
+				tableRow.appendChild(rowForContent);
+
+				table.appendChild(tableRow);
+			}) 
+		 }).catch( (error) =>{ 
+			console.log(error)
+		 });
+	}
+	getDojoData();
+})();


### PR DESCRIPTION
## レビューお願いいたします！！

<img width="948" alt="task5解答画像" src="https://user-images.githubusercontent.com/46079949/176827659-4b5961a7-39a3-4fd9-86b2-65f25412eb90.PNG">



## 実装要件
・⽇付/カテゴリー/タイトルが⼀覧形式で表⽰されること
→実装できました

・カテゴリーごとに⾊分けがされること
→実装できました

・タイトルをクリックすると、リンク先のURLに遷移すること
→targetが_selfなら同じウィンドウ、_blankなら別ウィンドウで開かせること
　→実装できました

・表⽰するニュースが増減しても、問題なく動作すること
→ニュースの件数の増減によってデザインが崩れないこと
　→実装できました

## 結果
実装できました