### PR TITLE
Dojo_task9 REST APIを使ってDojo_task7を再実装する

### DIFF
--- a/task9.js
+++ b/task9.js
@@ -11,19 +11,22 @@
 		
 		return kintone.api(kintone.api.url('/k/v1/records.json', true), 'GET', httpsRequestBody).then((resp) => {
 		
-			const handleDuplication = () => {
-				const result = window.confirm('レコードが重複しています。このまま保存しますか？');
-			  return result ? true:false;
-			}
-			
-			if (resp.records.length !== 0) {
-				return handleDuplication() ? event : false;
-			} 
-
 			if (resp.records.length === 0) {
 				return event;
 			}
 
+			const handleDuplication = () => {
+				const result = window.confirm('レコードが重複しています。このまま保存しますか？');
+			  return result;
+			}
+			
+			const res = handleDuplication();
+			
+			if (!res) {
+				return false;
+			}
+			
+			return event;
 		}).catch((error) =>{
 			console.log(error)
 		});

--- a/task9.js
+++ b/task9.js
@@ -1,30 +1,31 @@
 (() => {
 	'use strict';
-
-	const httpsRequestBody = {
-		"app":kintone.app.getId(),
-		"fields":["重複禁止項目"]
-	}
-
 	kintone.events.on('app.record.create.submit', (event) => {
 		const targetRecord = event.record.重複禁止項目.value;
+		const query = '重複禁止項目 = "' + targetRecord + '"';
+	
+		const httpsRequestBody = {
+			"app":kintone.app.getId(),
+			"query": query
+		}
+		
 		return kintone.api(kintone.api.url('/k/v1/records.json', true), 'GET', httpsRequestBody).then((resp) => {
+		
+			const handleDuplication = () => {
+				const result = window.confirm('レコードが重複しています。このまま保存しますか？');
+			  return result ? true:false;
+			}
 			
-			resp.records.forEach((respElem) => {
-				const refereceRecord = respElem.重複禁止項目.value
-				
-				if (refereceRecord === targetRecord) {
-					const result = window.confirm('レコードが重複しています。このまま保存しますか？');
-					if (!result) {
-						event.error = '処理を中断しました。'
-					}
-				}
-			});
+			if (resp.records.length !== 0) {
+				return handleDuplication() ? event : false;
+			} 
 
-			return event;
+			if (resp.records.length === 0) {
+				return event;
+			}
+
 		}).catch((error) =>{
 			console.log(error)
 		});
-		
 	});
 })();

--- a/task9.js
+++ b/task9.js
@@ -1,0 +1,30 @@
+(() => {
+	'use strict';
+
+	const httpsRequestBody = {
+		"app":kintone.app.getId(),
+		"fields":["重複禁止項目"]
+	}
+
+	kintone.events.on('app.record.create.submit', (event) => {
+		const targetRecord = event.record.重複禁止項目.value;
+		return kintone.api(kintone.api.url('/k/v1/records.json', true), 'GET', httpsRequestBody).then((resp) => {
+			
+			resp.records.forEach((respElem) => {
+				const refereceRecord = respElem.重複禁止項目.value
+				
+				if (refereceRecord === targetRecord) {
+					const result = window.confirm('レコードが重複しています。このまま保存しますか？');
+					if (!result) {
+						event.error = '処理を中断しました。'
+					}
+				}
+			});
+
+			return event;
+		}).catch((error) =>{
+			console.log(error)
+		});
+		
+	});
+})();

--- a/task9.js
+++ b/task9.js
@@ -28,7 +28,7 @@
 			
 			return event;
 		}).catch((error) =>{
-			console.log(error)
+			console.log(error);
 		});
 	});
 })();


### PR DESCRIPTION
## 実装要件
・レコードの重複を許可するかどうかはレコードごとにユーザーに任せる
→実装できました。ダイアログでOK/キャンセルを表示し、返り値に応じて処理を変えました。
　OKの場合：そのまま保存
　キャンセルの場合：エラー処理を出して保存を中断

・レコード保存ボタンを押したときのキャンセル処理
→event.errorにメッセージを付与する形で実装しました。

## 結果
実装できました。